### PR TITLE
Added Spationaut Suit to Salvage lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -75,6 +75,8 @@
       - id: MineralScanner
       - id: FlashlightSeclite
       - id: ClothingEyesGlassesMeson
+      - id: ClothingOuterHardsuitSpatio
+      # Gooble add due to needing hardsuit for non-lavaland
       # Lavaland Change End
 
 - type: entity
@@ -107,5 +109,7 @@
       - id: ClothingMaskGasExplorer
       - id: MineralScanner
       - id: FlashlightSeclite
+      - id: ClothingOuterHardsuitSpatio
+      # Gooble add due to needing hardsuit for non-lavaland
       # TODO: bluespace shelter capsule
       # Lavaland Change End


### PR DESCRIPTION
Added Spationaut Suit to Salvage lockers (hardsuit and non-hardsuit) to allow Salvager to start with a hardsuit as we do not have Lavaland right now.
