### PR TITLE
Trait Description + IPC dmg modifier revert

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
@@ -12,12 +12,10 @@
 - type: damageModifierSet
   id: IPC
   coefficients:
-    Blunt: 0.8
-    Slash: 0.8
-    Piercing: 0.8
     Heat: 1.7
     Shock: 2
   # Goobstation
-    Radiation: 0.4
+    Radiation: 0
+    Poison: 0
     Ion: 0.8
   ignoreArmorPierceFlags: All

--- a/Resources/Prototypes/_Funkystation/Traits/quirks.yml
+++ b/Resources/Prototypes/_Funkystation/Traits/quirks.yml
@@ -87,7 +87,7 @@
 - type: trait
   id: TableHider
   name: trait-table-hider-name
-  description: trait-table-hider-desc
+  description: You can sneak under objects like tables that no normal person should fit under, but you take extra damage.
   category: Quirks
   cost: 8 # Literally the rodentia action, blatant why it costs a lot.
   components:
@@ -103,7 +103,7 @@
 - type: trait
   id: SingerTrait
   name: trait-singer-name
-  description: trait-singer-desc
+  description: Sing your heart out!
   category: Quirks
   cost: 3 #feels right, it's just fun!
   components:
@@ -148,7 +148,7 @@
 - type: trait
   id: Resourceful
   name: trait-resourceful-name
-  description: trait-table-hider-desc
+  description: trait-resourceful-desc
   category: Quirks
   cost: 4
   components:


### PR DESCRIPTION
## About the PR
1) Fixed trait descriptions to say the proper phrases
2) Reverted IPC's physical damage back to how it was + no longer taking radiation damage

## Why / Balance
IPC's got their physical damage modifier reverted to how it was after a server vote. (Regular physical damage now instead of .8). IPC's also cannot be damaged by Radiation anymore due to the fact we do not have a method of healing that damage at all for IPC's.